### PR TITLE
Prevent error 'No 'Access-Control-Allow-Origin' header is present on …

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -5,7 +5,7 @@ block content
   p Welcome to #{title}
   script(src="/socket.io/socket.io.js")
   script.
-    var socket = io('//'+document.location.hostname);
+    var socket = io('//'+document.location.hostname+':'+document.location.port);
     socket.on('socketToMe', function (data) {
       console.log(data);
     });


### PR DESCRIPTION
…the requested resource.' by specifying the port in client side socket.io connect code

As per https://github.com/socketio/socket.io-client/issues/641.  Recent versions of socket.io have this issue.  This patch fixes the issue using socket.io@1.4.8.
