### PR TITLE
npm audit fix --force

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "body-parser": "~1.13.2",
+    "body-parser": "^1.18.3",
     "cookie-parser": "~1.3.5",
-    "debug": "~2.2.0",
-    "express": "~4.13.1",
+    "debug": "^4.1.1",
+    "express": "^4.16.4",
     "jade": "~1.11.0",
-    "morgan": "~1.6.1",
-    "serve-favicon": "~2.3.0",
-    "socket.io": "^1.3.7"
+    "morgan": "^1.9.1",
+    "serve-favicon": "^2.5.0",
+    "socket.io": "^2.2.0"
   }
 }


### PR DESCRIPTION
Update package.json to avoid npm deprecated warnings.
26 vulnerabilities packages (17 low, 3 moderate, 6 high).